### PR TITLE
Booking show images

### DIFF
--- a/app/views/bookings/show.html.erb
+++ b/app/views/bookings/show.html.erb
@@ -1,12 +1,13 @@
 <h1>Your Booking is Confirmed!</h1>
 <div class="card-container">
   <div class="card-trip">
-    <img src="https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/greece.jpg" />
+      <%= image_tag(@booking.listing.photos.first) %>
     <div class="card-trip-infos">
       <div>
         <h2><%= @booking.listing.title %></h2>
         <p><%= @booking.listing.description %></p>
         <p><%= @booking.start_at %> to <%= @booking.end_at %></p>
+        <p><%= @booking.notes %></p>
       </div>
       <h2 class="card-trip-pricing"><%= "$#{@booking.listing.fee}" %></h2>
       <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />


### PR DESCRIPTION
Now the booking show page will display the listing's photo instead of the default UI kit photo. :) 

<img width="1064" alt="Screenshot 2024-07-18 at 11 17 54 PM" src="https://github.com/user-attachments/assets/b4344cf2-79f2-412b-91c3-859dba1633cc">
