### PR TITLE
listings>card. description width is set to 700px

### DIFF
--- a/app/assets/stylesheets/components/_listings_card.scss
+++ b/app/assets/stylesheets/components/_listings_card.scss
@@ -72,6 +72,7 @@
 }
 
 .listing-description {
+  width:700px;
   font-size: 1em;
   margin-bottom: 20px;
   color: #666;


### PR DESCRIPTION
Added width to the description of the list item to avoid the card to break.