### PR TITLE
Listing time validations, Added 

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -33,6 +33,7 @@ class ListingsController < ApplicationController
 
   def new
     @listing = Listing.new
+    @listing.availabilities.build
   end
 
   def create
@@ -48,6 +49,6 @@ class ListingsController < ApplicationController
   private
 
   def listing_params
-    params.require(:listing).permit(:title, :description, :fee, :location, photos: [])
+    params.require(:listing).permit(:title, :description, :fee, :location, photos: [], availabilities_attributes: [:id, :start_time, :end_time, :_destroy])
   end
 end

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -1,0 +1,7 @@
+class Availability < ApplicationRecord
+  belongs_to :listing
+
+  scope :overlapping, ->(start_time, end_time) {
+    where.not("start_time > ? OR end_time < ?", end_time, start_time)
+  }
+end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -4,4 +4,14 @@ class Booking < ApplicationRecord
 
   validates :start_at, :end_at, presence: true
   validates_datetime :end_at, on_or_after: :start_at
+  validate :availability_check
+
+  private
+
+  def availability_check
+    overlaps = listing.availabilities.overlapping(start_at, end_at)
+    if overlaps.blank?
+      errors.add(:base, "The listing is not available during the selected time")
+    end
+  end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,9 +1,11 @@
 class Listing < ApplicationRecord
   belongs_to :user
   has_many :bookings
+  has_many :availabilities, inverse_of: :listing, dependent: :destroy
   has_many_attached :photos
   geocoded_by :location
   after_validation :geocode, if: :will_save_change_to_location?
+  accepts_nested_attributes_for :availabilities, allow_destroy: true
 
   include PgSearch::Model
   # Implements pg_search gem to allow for search bar functionality

--- a/app/views/listings/new.html.erb
+++ b/app/views/listings/new.html.erb
@@ -8,6 +8,10 @@
   wrapper_html: {data: {controller: "address-autocomplete", address_autocomplete_api_key_value: ENV["MAPBOX_API_KEY"]}}
   %>
   <%= f.input :fee %>
+    <%= f.simple_fields_for :availabilities do |availability_fields| %>
+    <%= availability_fields.input :start_time, as: :datetime, label: "Availability Start Time" %>
+    <%= availability_fields.input :end_time, as: :datetime, label: "Availability End Time" %>
+  <% end %>
   <%= f.input :photos, as: :file, input_html: { multiple: true } %>
   <%= f.submit %>
 <% end %>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -9,11 +9,19 @@
         <h1><%= @listing.title %></h1>
         <h5><%= @listing.description %></h5>
         <h2 class="card-trip-pricing"><%= "$#{@listing.fee} per hour" %></h2>
+        <% if @listing.availabilities.any? %>
+          <h3>--------------</h3>
+          <h3>Availability</h3>
+          <p>From: <%= @listing.availabilities.first.start_time.strftime("%B %d, %Y %H:%M") %></p>
+          <p>To: <%= @listing.availabilities.first.end_time.strftime("%B %d, %Y %H:%M") %></p>
+        <% else %>
+          <p>Not Currently Available</p>
+        <% end %>
       </div>
     </div>
   </div>
 
-  <% if @listing.user_id == current_user.id %>
+  <% if current_user && @listing.user_id == current_user.id %>
     <div class="upcoming-bookings-container flex-grow-1 ml-3">
       <h2>Upcoming Bookings</h2>
       <ul class="d-flex flex-wrap">
@@ -30,8 +38,18 @@
     <div class="container listing-bordered-container d-flex justify-content-center align-items-center flex-grow-1 ml-3">
       <div id="listing-form" class="mt-2">
         <%= simple_form_for [@listing, @booking] do |f| %>
-          <%= f.input :start_at, html5: true %>
-          <%= f.input :end_at, html5: true %>
+          <% if @booking.errors.any? %>
+            <div id="error_explanation">
+              <h2>Please Check the Following Error:</h2>
+              <ul>
+                <% @booking.errors.full_messages.each do |msg| %>
+                  <%= msg %>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+          <%= f.input :start_at, html5: true, minute_step: 15 %>
+          <%= f.input :end_at, html5: true, minute_step: 15 %>
           <%= f.input :notes %>
           <div class="text-center">
             <%= f.submit class: "btn btn-primary mb-3" %>
@@ -41,16 +59,15 @@
     </div>
   <% end %>
 
-</div>
-
   <div class="d-flex justify-content-center align-items-center">
     <%= link_to "Back to Listings", root_path, class: 'btn btn-outline-secondary mb-3' %>
   </div>
 </div>
+
 <%# <div> %>
-    <%# @listing.bookings.each do |booking|%>
-    <%#= booking.id %>
-    <%# end %>
+<%# @listing.bookings.each do |booking|%>
+<%#= booking.id %>
+<%# end %>
 <%# </div> %>
 
 <% if false %>

--- a/db/migrate/20240725105018_create_availabilities.rb
+++ b/db/migrate/20240725105018_create_availabilities.rb
@@ -1,0 +1,11 @@
+class CreateAvailabilities < ActiveRecord::Migration[7.1]
+  def change
+    create_table :availabilities do |t|
+      t.references :listing, null: false, foreign_key: true
+      t.datetime :start_time
+      t.datetime :end_time
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_22_005324) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_105018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_005324) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "availabilities", force: :cascade do |t|
+    t.bigint "listing_id", null: false
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["listing_id"], name: "index_availabilities_on_listing_id"
   end
 
   create_table "bookings", force: :cascade do |t|
@@ -89,6 +98,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_005324) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "availabilities", "listings"
   add_foreign_key "bookings", "listings"
   add_foreign_key "bookings", "users"
   add_foreign_key "listings", "users"

--- a/test/models/availability_test.rb
+++ b/test/models/availability_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AvailabilityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
I created an Availability model. Users can now add availability when creating a listing. (Not mandatory, but the listing says "not currently available" if nothing was entered).

The listing's availability is displayed on the listing show page. 

The booking form correctly validates against the listing availability and will not allow a booking outside of the availability. 

The errors need to be updated to be user friendly, and it would be nice if we could figure out how to make the availability format more of a "Mondays 9-5, Tuesdays 3-4" type of deal rather than datetime. I'm not sure right now how to do that, but I'm sure it's possible if we have time. 